### PR TITLE
Disable optimizations and include debugging symbols in debug builds on Linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -51,13 +51,13 @@ OUTPUT := $(OUTPUT).exe
 endif
 
 ifeq ($(BUILD_TYPE), debug)
-CFLAGS += -DDEBUG
-CPPFLAGS += -DDEBUG
+CFLAGS += -DDEBUG -g -O0
+CPPFLAGS += -DDEBUG -g -O0
 endif
 
 ifeq ($(BUILD_TYPE), debug_static)
-CFLAGS += -DDEBUG -static
-CPPFLAGS += -DDEBUG
+CFLAGS += -DDEBUG -static -g -O0
+CPPFLAGS += -DDEBUG -g -O0
 endif
 
 ifeq ($(BUILD_TYPE), release)


### PR DESCRIPTION
Makefile.linux did not make proper debug builds even with BUILD_TYPE=debug.

This changes it so it passes "-g" and "-O0" to the compiler, making it generate proper debugging symbols and disable optimizations (debug builds only) so it's possible to debug using gdb.